### PR TITLE
Using project.liveDirectory to get project_path instead of project.url.

### DIFF
--- a/content/gitbranch.js
+++ b/content/gitbranch.js
@@ -20,14 +20,11 @@ ko.extensions.gitbranch = {};
     };
     this.CurrentViewChanged = function() {
         var shell = require('ko/shell');
-        var koFile = require("ko/file");
-        // you can't do this:
-        //var file = require('ko/file');
         //log.debug("Current view changed.");
         var project = ko.projects.manager.currentProject;
         if (project && project.url) {
             //log.debug("We have a project path, finding git branch");
-            var project_path = koFile.dirname(ko.uriparse.URIToPath(project.url));
+            var project_path = project.liveDirectory;
             // log.debug("project_path is " + project_path);
             var commandname = "git --git-dir=" + project_path + "/.git --work-tree=" + project_path + " rev-parse --abbrev-ref HEAD";
             // log.debug("command to run is " + commandname);


### PR DESCRIPTION
Using project.url does not work if a project has changed the base directory. However, project.liveDirectory will work and it's already stored as an absolute path on the file system. No need for ko/file to map it.

Plus, project.liveDirectory will still work if the project has _not_ changed the base directory.

Great idea for a project! Thanks.
